### PR TITLE
Rename Cargo features to libstdc++ and libc++

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,13 @@ cc = "1.0"
 
 [features]
 default = [] # automatic
-libstdcxx = [] # force libstdc++
-libcxx = [] # force libc++
+"libstdc++" = [] # force libstdc++
+"libc++" = [] # force libc++
 nothing = [] # link nothing, determined somewhere else
+
+# deprecated aliases
+libstdcxx = ["libstdc++"]
+libcxx = ["libc++"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ An application that wants a particular one or the other linked should use:
 
 ```toml
 [dependencies]
-link-cplusplus = { version = "1.0", features = ["libstdcxx"] }
+link-cplusplus = { version = "1.0", features = ["libstdc++"] }
 
 # or
 
-link-cplusplus = { version = "1.0", features = ["libcxx"] }
+link-cplusplus = { version = "1.0", features = ["libc++"] }
 ```
 
 An application that wants to handle its own more complicated logic for link

--- a/build.rs
+++ b/build.rs
@@ -3,8 +3,8 @@ use std::fs;
 use std::path::PathBuf;
 
 fn main() {
-    let libstdcxx = cfg!(feature = "libstdcxx");
-    let libcxx = cfg!(feature = "libcxx");
+    let libstdcxx = cfg!(feature = "libstdc++");
+    let libcxx = cfg!(feature = "libc++");
     let nothing = cfg!(feature = "nothing");
 
     if nothing {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,11 +37,11 @@
 //!
 //! ```toml
 //! [dependencies]
-//! link-cplusplus = { version = "1.0", features = ["libstdcxx"] }
+//! link-cplusplus = { version = "1.0", features = ["libstdc++"] }
 //!
 //! # or
 //!
-//! link-cplusplus = { version = "1.0", features = ["libcxx"] }
+//! link-cplusplus = { version = "1.0", features = ["libc++"] }
 //! ```
 //!
 //! An application that wants to handle its own more complicated logic for link


### PR DESCRIPTION
Made possible by https://github.com/rust-lang/crates.io/pull/2510.