### PR TITLE
Eliminate implicit dependency on std crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,3 +62,5 @@
 //!
 //! extern crate link_cplusplus;
 //! ```
+
+#![no_std]


### PR DESCRIPTION
**Before:**

```rust
#![feature(prelude_import)]
#[prelude_import]
use std::prelude::rust_2018::*;
#[macro_use]
extern crate std;
```

**After:**

```rust
#![feature(prelude_import)]
#![no_std]
#[prelude_import]
use core::prelude::rust_2018::*;
#[macro_use]
extern crate core;
#[macro_use]
extern crate compiler_builtins;
```