### PR TITLE
Use the newly introduced two-colon prefix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "link-cplusplus"
-version = "1.0.9"
+version = "1.0.10"
 authors = ["David Tolnay <dtolnay@gmail.com>"]
 categories = ["external-ffi-bindings", "development-tools::ffi", "compilers", "no-std", "no-std::no-alloc"]
 description = "Link libstdc++ or libc++ automatically or manually"

--- a/build.rs
+++ b/build.rs
@@ -15,14 +15,14 @@ fn main() {
 
     if libstdcxx && libcxx {
         println!(
-            "cargo:warning=-lstdc++ and -lc++ are both requested, \
+            "cargo::warning=-lstdc++ and -lc++ are both requested, \
              using the platform's default"
         );
     }
 
     match (libstdcxx, libcxx) {
-        (true, false) => println!("cargo:rustc-link-lib=stdc++"),
-        (false, true) => println!("cargo:rustc-link-lib=c++"),
+        (true, false) => println!("cargo::rustc-link-lib=stdc++"),
+        (false, true) => println!("cargo::rustc-link-lib=c++"),
         (false, false) | (true, true) => {
             // The platform's default.
             let out_dir = env::var_os("OUT_DIR").expect("missing OUT_DIR");


### PR DESCRIPTION
https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script